### PR TITLE
Add link-ippvm, allows for static linking on linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ members = [
     "link-ippcv",
     "link-ippi",
     "link-ipps",
+    "link-ippvm",
     ]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This directory contains several crates:
  - `link-ippcv`: link ippcv library
  - `link-ippi`: link ippi library
  - `link-ipps`: link ipps library
+ - `link-ippvm`: link ippvm library
 
 Typically, you can just depend on `ipp-sys`. The `link-*` crates do not provide
 any rust code, but only serve to link the relevant IPP library. There are

--- a/ipp-sys/src/lib.rs
+++ b/ipp-sys/src/lib.rs
@@ -71,13 +71,15 @@ See the [ipp-headers-sys page on docs.rs](http://docs.rs/ipp-headers-sys).
 // The link* creates are used to link the library.
 #![allow(unused_extern_crates)]
 extern crate ipp_headers_sys;
-#[cfg(feature="do-linking")]
+#[cfg(feature = "do-linking")]
 extern crate link_ippcore;
-#[cfg(feature="do-linking")]
+#[cfg(feature = "do-linking")]
 extern crate link_ippcv;
-#[cfg(feature="do-linking")]
+#[cfg(feature = "do-linking")]
 extern crate link_ippi;
-#[cfg(feature="do-linking")]
+#[cfg(feature = "do-linking")]
 extern crate link_ipps;
+#[cfg(feature = "do-linking")]
+extern crate link_ippvm;
 
 pub use ipp_headers_sys::*;

--- a/link-ippvm/Cargo.toml
+++ b/link-ippvm/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "link-ippvm"
+description = "link ippvm library (part of ipp-sys Intel IPP bindings)"
+version = "0.1.0"
+authors = ["Andrew Straw <strawman@astraw.com>"]
+build = "build.rs"
+links = "libippvm"
+license = "MIT/Apache-2.0"
+categories = ["external-ffi-bindings"]
+readme = "README.md"
+
+[dependencies]
+link-ippcore = "0.1"
+
+[build-dependencies]
+ipp-sys-build-help = "0.1.2"

--- a/link-ippvm/README.md
+++ b/link-ippvm/README.md
@@ -1,0 +1,4 @@
+# link-ippvm - link ippvm library
+
+This crate is part of the `ipp-sys` Rust Intel IPP bindings. See
+[ipp-sys](https://github.com/astraw/ipp-sys) for more information.

--- a/link-ippvm/build.rs
+++ b/link-ippvm/build.rs
@@ -1,0 +1,5 @@
+extern crate ipp_sys_build_help;
+
+fn main() {
+    ipp_sys_build_help::ipp_build("ippvm");
+}

--- a/link-ippvm/src/lib.rs
+++ b/link-ippvm/src/lib.rs
@@ -1,0 +1,2 @@
+#![allow(unused_extern_crates)]
+extern crate link_ippcore;


### PR DESCRIPTION
When trying to statically link (2019.5.281) on Linux, some functions from ipps depends on ippvm. Adding this seems to fix static linking, but my testing has been limited to just Linux and that IPP version.

link-ipps might need to depend on link-ippvm, in addition to these changes.