### PR TITLE
link-ipps depends on link-ippvm

### DIFF
--- a/link-ipps/Cargo.toml
+++ b/link-ipps/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 
 [dependencies]
 link-ippcore = { version = "0.1", path = "../link-ippcore" }
+link-ippvm = { version = "0.1", path = "../link-ippvm" }
 
 [build-dependencies]
 ipp-sys-build-help = { version = "0.1.2", path = "../ipp-sys-build-help" }

--- a/link-ipps/src/lib.rs
+++ b/link-ipps/src/lib.rs
@@ -1,2 +1,3 @@
 #[allow(unused_extern_crates)]
 extern crate link_ippcore;
+extern crate link_ippvm;


### PR DESCRIPTION
Looks like link-ipps needs to depend on link-ippvm to statically build on Linux 
In my last PR I was testing by manually linking in just the link-libvm instead of through ipps-sys. I'm not sure if there are other cross lib dependencies. But for what I was doing it was missing y8_ippsSin_32f_A24 (and a few similarly named functions), which are only referenced in libipps.a and libippvm.a